### PR TITLE
'mkl_spblas.h' needed for mkl

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ cp -r scripts\*.bat .\
 If you have Intel MKL available, you can use it to build ArrayFire. To setup MKL for ArrayFire, follow the steps:
 * Create directory dependencies/mkl
 * Create directories include, bin, lib in mkl
-* Copy `fftw3.h, mkl_blas.h, mkl_cblas.h, mkl_lapacke.h, mkl_types.h` into mkl/include
+* Copy `fftw3.h, mkl_blas.h, mkl_cblas.h, mkl_lapacke.h, mkl_types.h, mkl_spblas.h` into mkl/include
 * Copy `mkl_core_dll.lib, mkl_rt.lib` into mkl/lib
-* Copy `mkl_core.dll, mkl_rt.dll, mkl_intel_thread.dll, mkl_rt.dll` into mkl/bin
+* Copy `mkl_core.dll, mkl_rt.dll, mkl_intel_thread.dll` into mkl/bin
 
 This will allow you to use the default setup in the build scripts. You may choose not to copy these, but then will have to configure common.bat to set it up correctly.
 


### PR DESCRIPTION
In the description of what files are required for use with mkl there 'mkl_spblas.h' is now included. Also removed duplicate mention of 'mkl_rt.dll'